### PR TITLE
[COMMON] 메인 페이지 추천 관광지 API 구현

### DIFF
--- a/common/src/main/java/com/project/hiptour/common/place/controller/PlaceController.java
+++ b/common/src/main/java/com/project/hiptour/common/place/controller/PlaceController.java
@@ -4,10 +4,9 @@ import com.project.hiptour.common.place.dto.PlaceDto;
 import com.project.hiptour.common.place.service.PlaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/places")
@@ -19,5 +18,11 @@ public class PlaceController {
     public ResponseEntity<PlaceDto> getPlace(@PathVariable("id") Integer id) {
         PlaceDto placeDto = placeService.findPlace(id);
         return ResponseEntity.ok(placeDto);
+    }
+
+    @GetMapping("/recommended")
+    public ResponseEntity<List<PlaceDto>> getRecommendedPlaces(@RequestParam(defaultValue = "10") int limit) {
+        List<PlaceDto> recommendedPlaces = placeService.findRecommendedPlaces(limit);
+        return ResponseEntity.ok(recommendedPlaces);
     }
 }

--- a/common/src/main/java/com/project/hiptour/common/place/repository/PlaceRepository.java
+++ b/common/src/main/java/com/project/hiptour/common/place/repository/PlaceRepository.java
@@ -1,9 +1,23 @@
 package com.project.hiptour.common.place.repository;
 
 import com.project.hiptour.common.entity.place.Place;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
 
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, Integer> {
+    @Query("SELECT p FROM Place p " +
+            "LEFT JOIN Heart h ON p.placeId = h.feed.placeId AND h.isActive = true " +
+            "GROUP BY p.placeId " +
+            "ORDER BY COUNT(h) DESC")
+    List<Place> findPlacesOrderByHeartCount(Pageable pageable);
+
+    List<Place> findByPlaceIdNotInOrderByCreatedAtDesc(Collection<Integer> placeIds, Pageable pageable);
+
+    List<Place> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/common/src/main/java/com/project/hiptour/common/place/service/PlaceService.java
+++ b/common/src/main/java/com/project/hiptour/common/place/service/PlaceService.java
@@ -5,8 +5,14 @@ import com.project.hiptour.common.place.dto.PlaceDto;
 import com.project.hiptour.common.place.repository.PlaceRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -18,5 +24,31 @@ public class PlaceService {
         Place place = placeRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("장소를 찾지 못했습니다: " + id));
         return PlaceDto.from(place);
+    }
+
+    public List<PlaceDto> findRecommendedPlaces(int limit) {
+        Pageable pageable = PageRequest.of(0, limit);
+        List<Place> likedPlaces = placeRepository.findPlacesOrderByHeartCount(pageable);
+
+        if (likedPlaces.size() < limit) {
+            int remainingLimit = limit - likedPlaces.size();
+            Pageable remainingPageable = PageRequest.of(0, remainingLimit);
+
+            List<Place> recentPlaces;
+            if (likedPlaces.isEmpty()) {
+                recentPlaces = placeRepository.findAllByOrderByCreatedAtDesc(remainingPageable);
+            } else {
+                Collection<Integer> excludeIds = likedPlaces.stream()
+                        .map(Place::getPlaceId)
+                        .collect(Collectors.toList());
+                recentPlaces = placeRepository.findByPlaceIdNotInOrderByCreatedAtDesc(excludeIds, remainingPageable);
+            }
+
+            likedPlaces.addAll(recentPlaces);
+        }
+
+        return likedPlaces.stream()
+                .map(PlaceDto::from)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
찜 개수 기반 추천 로직 구현
- 여행지에 대한 관심도를 나타내는 찜(Heart)이 많은 순서로 여행지를 추천하는 기능 구현

콜드 스타트 문제 해결
- 초기 기획에는 없었으나 개발 과정에서 콜드 스타트 문제 발견
- 서비스 초기에는 찜 개수에 대한 데이터 부재
    - 찜 개수 순으로 조회된 결과가 부족할 경우 최신 등록순 으로 데이터 보충하여 limt을 채워 반환합니다.

API 엔드포인트 추가
- GET /api/places/recommended 엔드포인트를 PlaceController에 추가